### PR TITLE
bugfix/tinyfpga-bx-flash-wonkiness

### DIFF
--- a/gateware/dragonBoot/flash.py
+++ b/gateware/dragonBoot/flash.py
@@ -137,6 +137,14 @@ class SPIFlash(Elaboratable):
 		]
 
 		with m.FSM(name = 'flash'):
+			with m.State('PRE_RESET_WAIT'):
+				m.d.sync += resetTimer.dec()
+				with m.If(resetTimer == 0):
+					m.d.sync += [
+						resetTimer.eq(resetTimer.reset),
+						resetStep.eq(0),
+					]
+					m.next = 'RESET'
 			with m.State('RESET'):
 				with m.Switch(resetStep):
 					with m.Case(0):
@@ -150,10 +158,7 @@ class SPIFlash(Elaboratable):
 						]
 					with m.Case(1):
 						with m.If(flash.done):
-							m.d.sync += [
-								flash.cs.eq(0),
-								enableStep.eq(0),
-							]
+							m.d.sync += flash.cs.eq(0)
 							m.next = 'RESET_WAIT'
 			with m.State('RESET_WAIT'):
 				m.d.sync += resetTimer.dec()
@@ -180,6 +185,7 @@ class SPIFlash(Elaboratable):
 					m.d.sync += [
 						op.eq(SPIFlashOp.erase),
 						byteCount.eq(self.byteCount),
+						enableStep.eq(0),
 					]
 					m.next = 'WRITE_ENABLE'
 			with m.State('WRITE_ENABLE'):

--- a/gateware/dragonBoot/flash.py
+++ b/gateware/dragonBoot/flash.py
@@ -185,7 +185,6 @@ class SPIFlash(Elaboratable):
 					m.d.sync += [
 						op.eq(SPIFlashOp.erase),
 						byteCount.eq(self.byteCount),
-						enableStep.eq(0),
 					]
 					m.next = 'WRITE_ENABLE'
 			with m.State('WRITE_ENABLE'):


### PR DESCRIPTION
All changes made by me (and via discussion with @dragonmux) to fix problems with dfu loading on TinyFPGA-BX.

Current state: dfu downloads now work, booting into dfu slot 1 works when board is not connected to USB.

* Put flash.cs de-assert into the correct place after issuing RESET but before RESET_WAIT
* Added pre-reset timeout to flash.py